### PR TITLE
Run annotation processor through annotationProcessorPaths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${jmh.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- junit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -104,6 +98,13 @@ THE POSSIBILITY OF SUCH DAMAGE.
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.openjdk.jmh</groupId>
+                                <artifactId>jmh-generator-annprocess</artifactId>
+                                <version>${jmh.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Run the JMH annotation processor through `<annotationProcessorPaths>` of the compiler plugin rather than a provided dependency.

See the Maven plugin documentation https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths

This allows the IDE to run the annotation processor. In Eclipse with m2e you have to do

<img width="787" alt="m2e-configuration" src="https://github.com/Xceptance/jmh-training/assets/471021/44c153b6-663a-4797-b69b-fd40fe7c7416">
